### PR TITLE
Fix column order for CSV

### DIFF
--- a/windowsprefetch/scripts/prefetch.py
+++ b/windowsprefetch/scripts/prefetch.py
@@ -32,7 +32,7 @@ def main():
                 parsed_files.append(p)
 
     if args.csv:
-        print("Timestamp,Executable Name,MFT Seq Number,MFT Entry Number,Prefetch Hash,Run Count")
+        print("Timestamp,Executable Name,Prefetch Hash,MFT Seq Number,MFT Entry Number,Run Count")
 
     for p in parsed_files:
         if args.csv:


### PR DESCRIPTION
Reorder the column headers for the CSV output to match the order of data